### PR TITLE
Allow to extend with decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ rails generate ahoy_events:active_record
 rake db:migrate
 ```
 
+#### Extend `Ahoy::Event` model
+
+You can use decorators to extend the `Ahoy::Event` model.
+
+For example, you could add the scope `between` in `app/decorators/ahoy/event_decorator.rb`:
+
+```ruby
+Ahoy::Event.class_eval do
+  scope :between, ->(from, to) { where(["time >= ? AND time <= ?", from, to]) }
+end
+```
+
 ### Custom
 
 Create your own subscribers in `config/initializers/ahoy.rb`.

--- a/lib/ahoy_events/engine.rb
+++ b/lib/ahoy_events/engine.rb
@@ -1,4 +1,11 @@
 module AhoyEvents
   class Engine < ::Rails::Engine
+    isolate_namespace AhoyEvents
+
+    config.to_prepare do
+      Dir.glob(Rails.root + "app/decorators/**/*_decorator*.rb").each do |c|
+        require_dependency(c)
+      end
+    end
   end
 end


### PR DESCRIPTION
Allow to use decorators to extend the `Ahoy::Event` model.
